### PR TITLE
Default expected stamp to empty string when null

### DIFF
--- a/src/Microsoft.AspNet.Identity.Owin/DataProtectorTokenProvider.cs
+++ b/src/Microsoft.AspNet.Identity.Owin/DataProtectorTokenProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.Identity.Owin
 
                     if (manager.SupportsUserSecurityStamp)
                     {
-                        var expectedStamp = await manager.GetSecurityStampAsync(user.Id).WithCurrentCulture();
+                        var expectedStamp = await manager.GetSecurityStampAsync(user.Id).WithCurrentCulture() ?? string.Empty;
                         return stamp == expectedStamp;
                     }
                     return stamp == "";


### PR DESCRIPTION
I discovered a flaw within the ValidateAsync method around expected stamp. The GenerateAsync method if it reads NULL out of GetSecurityStampAsync will write an empty string into the memory stream. I assume that is the case because one can not write NULL into a memory stream but if the security stamp column in the database is NULL, validating a token will fail.

The simplest fix seems to be to default the expected stamp to an empty string when none is found.