### PR TITLE
Remove internal package sources

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -22,8 +22,6 @@
             <PackageSource Include="https://nuget.org/api/v2/" />
             <PackageSource Include="https://my-nuget-source/nuget/" />
         -->
-        <PackageSource Include="\\wsr-teamcity\Drops\Katana.Release.Signed\latest-successful\Release" />
-        <PackageSource Include="\\wsr-teamcity\Drops\EF.601Beta1.Signed.English\latest-successful\Signed\Packages" />
         <PackageSource Include="http://myget.org/F/owin" />
         <PackageSource Include="https://nuget.org/api/v2/" />
     </ItemGroup>


### PR DESCRIPTION
@HaoK these internal sources are breaking the CI build. They don't actually exist, but for some reason it's trying to restore only from them. 

Also, I had issues with having NuGet download itself locally on my machine. Not sure if there will be an issue with the CI. I manually downloaded 4.1 and was able to build everything locally.